### PR TITLE
Hot fix feedback

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,19 +1,23 @@
 import pandas as pd
 import src.utils as utils
 import src.data_process as dp
+from src.parser import parser
 
 
-def main(output: str, fancy_header: bool):
+def main(input_file: str, output_file: str, fancy_header: bool):
     """
     Main function of the script.
     Parameters:
 
-        - output: string. Indicates the path of the output file
+        - input_file: string. Indicates the path of the input file
+
+        - output_file: string. Indicates the path of the output file
 
         - fancy_header: boolean.
         If the user want the output file header to be separated by |
     """
-    with open('pretrade_current.txt', 'r') as buffer:
+
+    with open(input_file, 'r') as buffer:
         msg_type, _ = utils.get_msgType_dict(buffer)
 
     df8 = utils.generate_DataFrame_by_type_id('8', input_table=msg_type)
@@ -29,16 +33,19 @@ def main(output: str, fancy_header: bool):
         )
 
     if not fancy_header:
-        df.to_csv(output, sep='\t', index=False, na_rep='NA')
+        df.to_csv(output_file, sep='\t', index=False, na_rep='NA')
     else:
-        with open(output, 'w') as filepath:
+        with open(output_file, 'w') as filepath:
             filepath.write(' | '.join(df.columns))
         df.to_csv(
-            output, sep='\t',
+            output_file, sep='\t',
             index=False, header=False,
             na_rep='NA', mode='a'
         )
 
 
 if __name__ == '__main__':
-    main('aggregate_output.tsv', fancy_header=False)
+    args = vars(parser.parse_args())
+    input_str = args.get('inputfile')
+    output_str = args.get('outputfile')
+    main(input_str, output_str, fancy_header=False)

--- a/src/parser.py
+++ b/src/parser.py
@@ -1,0 +1,17 @@
+import argparse
+
+parser = argparse.ArgumentParser("Process record data")
+parser.add_argument(
+    '-i',
+    '--input',
+    help= "Input file path. Expects only 1 file.",
+    default='pretrade_current.txt',
+    dest='inputfile'
+    )
+parser.add_argument(
+    '-o',
+    '--output',
+    help= "Output file path.",
+    default='aggregate_output.tsv',
+    dest='outputfile'
+    )

--- a/src/utils.py
+++ b/src/utils.py
@@ -38,7 +38,7 @@ def get_msgType_dict(
 
 
 def generate_DataFrame_by_type_id(
-    type_id: Union[str, int], input_table: dict[str, List[str]]
+    type_id: Union[str, int], input_table: Dict[str, List[str]]
 ) -> pd.DataFrame:
     """
     Provided an Id for the type of messages required, this functions


### PR DESCRIPTION
The issue reported by Viet Lee was cause by an incompatibility between python3.10 and python3.8.

The latest version (3.10) allows for this kind of type hint:
`argument: dict[Type, Type]` 
where we can assign subtypes directly to the `dict` object.

In python 3.8 this is not allowed and raises `TypeError: 'type' object is not subscriptable`.
It is easily fixable by using 
`argument: Dict[Type, Type]